### PR TITLE
working js_binary example

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -26,6 +26,7 @@ js_binary(
 ts_project(
     name = "thing",
     srcs = [
+        "main.ts",
         "thing.ts",
     ],
     deps = [
@@ -59,7 +60,7 @@ jest_test(
 js_binary(
     name = "thing_js",
     data = ["thing"],
-    entry_point = "thing.js",
+    entry_point = "main.js",
 )
 
 gqlgen(

--- a/main.ts
+++ b/main.ts
@@ -1,0 +1,3 @@
+import thing from "./thing";
+
+console.log(thing().author)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "graphql-codgen-repro",
   "version": "1.0.0",
   "description": "bazel example for graphql codegen",
-  "main": "index.js",
   "dependencies": {
     "@types/jest": "^29.2.0",
     "graphql": "16.6.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "compilerOptions": {
-    "lib": ["ES2021"],
+    "lib": [
+      "dom",
+      "ES2021"
+    ],
     "baseUrl": "./",
     "paths": {
       "monorepo/*": [


### PR DESCRIPTION
includes a local relative import that depends on generated graphql and console.logs the result